### PR TITLE
Pass along headers from backend if present.

### DIFF
--- a/docker/nginx/conf.d/zipstream.conf
+++ b/docker/nginx/conf.d/zipstream.conf
@@ -73,7 +73,8 @@ server {
     # and list of files that engage zipstream.
     location /application {
         add_header X-Archive-Files zip;
-        more_set_headers 'Content-Type: text/plain';
+        more_set_headers 'Content-Type: application/zip';
+        more_set_headers 'Content-Disposition: attachment; filename=foobar.zip';
         return 200 '080934 8 /hello.txt test/Hello!.txt\n2323 23 /good%20bye.txt Good Bye.txt\n- - /f©®βàr¡.txt f©®βàr¡.txt\n- - /404 /404.txt\n- - /500 500.txt';
     }
 }


### PR DESCRIPTION
If `Content-Type` or `Content-Disposition` are set by backend, proxy them.

Closes #6 