### PR TITLE
Don't copy headers. Set archive member permissions.

### DIFF
--- a/lua/nginx_lua_zipstream.lua
+++ b/lua/nginx_lua_zipstream.lua
@@ -129,7 +129,7 @@ local stream_zip = function(file_list)
             isdir = false,
             platform = 'unix',
             exattrib = {
-                -- unix permissions: "-rw-rw-rw-""
+                -- unix permissions: "-rw-rw----""
                 ZipWriter.NIX_FILE_ATTR.IFREG,
                 ZipWriter.NIX_FILE_ATTR.IRUSR,
                 ZipWriter.NIX_FILE_ATTR.IWUSR,

--- a/lua/nginx_lua_zipstream.lua
+++ b/lua/nginx_lua_zipstream.lua
@@ -58,11 +58,6 @@ local res = ngx.location.capture(UPSTREAM, { method = method_id })
 -- Get magic header.
 local archive = res.header[HEADER_NAME]
 
--- Pass along headers
-for k, v in pairs(res.header) do
-    ngx.header[k] = v
-end
-
 -- If header value is not "zip", forward response downstream. We may
 -- support other archive formats in the future.
 -- TODO: maybe return an error?
@@ -131,6 +126,22 @@ local stream_zip = function(file_list)
         local desc = {
             istext = true,
             isfile = true,
+            isdir = false,
+            platform = 'unix',
+            exattrib = {
+                -- unix permissions: "-rw-rw-rw-""
+                ZipWriter.NIX_FILE_ATTR.IFREG,
+                ZipWriter.NIX_FILE_ATTR.IRUSR,
+                ZipWriter.NIX_FILE_ATTR.IWUSR,
+                ZipWriter.NIX_FILE_ATTR.IRGRP,
+                ZipWriter.NIX_FILE_ATTR.IWGRP,
+                ZipWriter.NIX_FILE_ATTR.IROTH,
+                ZipWriter.NIX_FILE_ATTR.IWOTH,
+
+                -- DOS: normal, changed since last archive.
+                ZipWriter.DOS_FILE_ATTR.ARCH,
+                ZipWriter.DOS_FILE_ATTR.NORMAL,
+            },
         }
 
         -- Finally return the file information and a function that will

--- a/lua/nginx_lua_zipstream.lua
+++ b/lua/nginx_lua_zipstream.lua
@@ -135,8 +135,6 @@ local stream_zip = function(file_list)
                 ZipWriter.NIX_FILE_ATTR.IWUSR,
                 ZipWriter.NIX_FILE_ATTR.IRGRP,
                 ZipWriter.NIX_FILE_ATTR.IWGRP,
-                ZipWriter.NIX_FILE_ATTR.IROTH,
-                ZipWriter.NIX_FILE_ATTR.IWOTH,
 
                 -- DOS: normal, changed since last archive.
                 ZipWriter.DOS_FILE_ATTR.ARCH,


### PR DESCRIPTION
Copying headers caused the response to be truncated (due to copying `Content-Length`). Safer not to copy the headers from the backend.

Also, set permissions (`-rw-rw----`) for each archive entry.

After merging this, update:

https://github.com/smartfile/base-images/blob/master/docker/openresty/Dockerfile#L7

With the full commit hash.